### PR TITLE
respect parent deleteKey function.

### DIFF
--- a/attributes/page_selector/controller.php
+++ b/attributes/page_selector/controller.php
@@ -57,6 +57,9 @@ class Controller extends \Concrete\Core\Attribute\Controller  {
 	}
 
 	public function deleteKey() {
+		
+		parent::deleteKey();
+		
 		$db = Loader::db();
 		$arr = $this->attributeKey->getAttributeValueIDList();
 		foreach($arr as $id) {


### PR DESCRIPTION
With this call to parent deleteKey the settings entries are also removed. This prevents error messages during package unistall.

see here: [https://www.concrete5.org/developers/bugs/8-4-1/cant-uninstall-package](https://www.concrete5.org/developers/bugs/8-4-1/cant-uninstall-package)