### PR TITLE
Modernize page_selector attribute

### DIFF
--- a/attributes/page_selector/controller.php
+++ b/attributes/page_selector/controller.php
@@ -1,78 +1,150 @@
 <?php
+
 namespace Concrete\Package\EasyImageGallery\Attribute\PageSelector;
 
-use Page;
-use Loader;
-defined('C5_EXECUTE') or die("Access Denied.");
+use Concrete\Core\Attribute\Controller as CoreController;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Page\Page;
 
-class Controller extends \Concrete\Core\Attribute\Controller  {
+defined('C5_EXECUTE') or die('Access Denied.');
 
-  protected $searchIndexFieldDefinition = array('type' => 'integer', 'options' => array('default' => 0, 'notnull' => false));
+class Controller extends CoreController
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::$searchIndexFieldDefinition
+     */
+    protected $searchIndexFieldDefinition = [
+        'type' => 'integer',
+        'options' => ['default' => 0, 'notnull' => false],
+    ];
 
-	public function getValue() {
-		$db = Loader::db();
-		$value = $db->GetOne("select value from atPageSelector where avID = ?", array($this->getAttributeValueID()));
-		return $value;
-	}
-  public function getDisplayValue()
-  {
-      $c = Page::getByID($this->getValue());
-      if (is_object($c)) {
-          return '<a href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>';
-      }
-  }
-  public function getDisplaySanitizedValue()
-  {
-      return $this->getDisplayValue();
-  }
-	public function searchForm($list) {
-		$PagecID = $this->request('value');
-		$list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $PagecID, '=');
-		return $list;
-	}
+    /**
+     * @return int
+     */
+    public function getValue()
+    {
+        $cn = $this->app->make(Connection::class);
 
-	public function search() {
-		$form_selector = Loader::helper('form/page_selector');
-		print $form_selector->selectPage($this->field('value'), $this->request('value'), false);
-	}
+        return (int) $cn->fetchColumn('select value from atPageSelector where avID = ?', [$this->getAttributeValueID()]);
+    }
 
-	public function form() {
-		if (is_object($this->attributeValue)) {
-			$value = $this->getAttributeValue()->getValue();
-		}
-		$form_selector = Loader::helper('form/page_selector');
-		print $form_selector->selectPage($this->field('value'), $value);
-	}
-
-	public function validateForm($p) {
-		return $p['value'] != 0;
-	}
-
-	public function saveValue($value) {
-		$db = Loader::db();
-        if(!intval($value)) {
-            $value = 0;
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::getDisplayValue()
+     *
+     * @return string|null
+     */
+    public function getDisplayValue()
+    {
+        $cID = $this->getValue();
+        if ($cID > 0) {
+            $c = Page::getByID($cID);
+            if ($c && !$c->isError()) {
+                return '<a href="' . h($c->getCollectionLink()) . '">' . h($c->getCollectionName()) . '</a>';
+            }
         }
-		$db->Replace('atPageSelector', array('avID' => $this->getAttributeValueID(), 'value' => $value), 'avID', true);
-	}
+    }
 
-	public function deleteKey() {
-		$db = Loader::db();
-		$arr = $this->attributeKey->getAttributeValueIDList();
-		foreach($arr as $id) {
-			$db->Execute('delete from atPageSelector where avID = ?', array($id));
-		}
-		parent::deleteKey();
-	}
+    /**
+     * @return string|null
+     */
+    public function getDisplaySanitizedValue()
+    {
+        return $this->getDisplayValue();
+    }
 
-	public function saveForm($data) {
-		$db = Loader::db();
-		$this->saveValue($data['value']);
-	}
+    public function searchForm($list)
+    {
+        $cID = $this->request('value');
+        $list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $cID, '=');
 
-	public function deleteValue() {
-		$db = Loader::db();
-		$db->Execute('delete from atPageSelector where avID = ?', array($this->getAttributeValueID()));
-	}
+        return $list;
+    }
 
+    public function search()
+    {
+        $formSelector = $this->app->make('helper/form/page_selector');
+        echo $formSelector->selectPage($this->field('value'), $this->request('value'), false);
+    }
+
+    public function form()
+    {
+        $value = is_object($this->attributeValue) ? $this->getAttributeValue()->getValue() : null;
+        $formSelector = $this->app->make('helper/form/page_selector');
+        echo $formSelector->selectPage($this->field('value'), $value);
+    }
+
+    /**
+     * @param array $p
+     *
+     * @return bool
+     */
+    public function validateForm($p)
+    {
+        if (empty($p['value'])) {
+            return false;
+        }
+        return ((int) $p['value']) !== 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::saveValue()
+     */
+    public function saveValue($value)
+    {
+        $cn = $this->app->make(Connection::class);
+        $value = (int) $value;
+        $cn->replace(
+            // $table
+            'atPageSelector',
+            // $fieldArray
+            ['avID' => $this->getAttributeValueID(), 'value' => $value],
+            // $keyCol
+            'avID',
+            // $autoQuote
+            true
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::deleteKey()
+     */
+    public function deleteKey()
+    {
+        $cn = $this->app->make(Connection::class);
+        $arr = $this->attributeKey->getAttributeValueIDList();
+        foreach($arr as $id) {
+            $cn->delete('atPageSelector', ['avID' => $id]);
+        }
+        parent::deleteKey();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::saveForm()
+     */
+    public function saveForm($data)
+    {
+        $this->saveValue(isset($data['value']) ? $data['value'] : null);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::deleteValue()
+     */
+    public function deleteValue()
+    {
+        $cn = $this->app->make(Connection::class);
+        $cn->delete('atPageSelector', ['avID' => $this->getAttributeValueID()]);
+        parent::deleteValue();
+    }
 }

--- a/attributes/page_selector/db.xml
+++ b/attributes/page_selector/db.xml
@@ -1,14 +1,19 @@
-<?xml version="1.0"?>
-<schema version="0.3">
-<table name="atPageSelector">
-    <field name="avID" type="I" size="10">
-      <KEY/>
-      <DEFAULT value="0"/>
-      <UNSIGNED/>
-    </field>
-   <field name="value" type="I">
-      <NOTNULL/>
-      <DEFAULT value="0"/>
-    </field>
-  </table>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.concrete5.org/doctrine-xml/0.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.concrete5.org/doctrine-xml/0.5 https://concretecms.github.io/doctrine-xml/doctrine-xml-0.5.xsd"
+>
+
+    <table name="atPageSelector">
+        <field name="avID" type="integer" size="10">
+            <unsigned />
+            <key />
+            <default value="0" />
+        </field>
+        <field name="value" type="integer">
+            <default value="0" />
+            <notnull />
+        </field>
+    </table>
+
 </schema>


### PR DESCRIPTION
The Page Selector attribute is available since concrete5 8.4.1, but let's keep it here to avoid breaking existing installatios.